### PR TITLE
Create pipeline for auto-generating first summary page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__/
 .ipynb_checkpoints/
+viz/

--- a/src/agency.py
+++ b/src/agency.py
@@ -104,13 +104,15 @@ class Agency():
         Returns the goal status of the passed APG.
 
         :param goal_name: The name of the APG from which a status will be returned.
-        :param year: The year from which to retrieve goal status. Defaults to the year that the object represents, "all" returns the data from all years and quarters.
-        :param quarter: The quarter from which to retrieve goal status. Defaults to the quarter that the object represents, "all" returns the data from all years and quarters.
+        :param year: The year from which to retrieve goal status. Defaults to the year that the object represents.
+        :param quarter: The quarter from which to retrieve goal status. Defaults to the quarter that the object represents. "previous" returns the data only from the previous quarter.
         """
         if not year:
             year = self.current_year
         if not quarter:
             quarter = self.current_quarter
+        elif quarter == "previous":
+            quarter, year = utility.get_previous_quarter_and_year(self.current_quarter, self.current_year)
 
         try:
             return self.agency_df.loc[(self.df["Goal Name"] == goal_name) & (self.agency_df["Fiscal Year"] == year) & (self.agency_df["Quarter"] == quarter), "Status"].iloc[0]

--- a/src/agency.py
+++ b/src/agency.py
@@ -1,4 +1,5 @@
 import utility
+import pandas as pd
 
 class Agency():
     

--- a/src/main.py
+++ b/src/main.py
@@ -3,4 +3,4 @@ import agency
 import pandas as pd
 
 sba = agency.Agency(pd.read_csv("../dummy_cover_sheet_data.csv"), "SBA", "Q4", 2020)
-output_creation.create_summary_document("./Summary_Report_Template.docx", sba)
+output_creation.create_summary_document("../Summary_Report_Template.docx", sba)

--- a/src/output_creation.py
+++ b/src/output_creation.py
@@ -4,6 +4,7 @@ Maps keywords imbedded in template document (keys) to what they will be replaced
 
 import utility
 import agency
+import text_templates
 
 from docx.text.paragraph import Paragraph
 from docxtpl import DocxTemplate
@@ -41,7 +42,9 @@ def create_summary_document(template_path, agency):
     replacement_map = {
         "previous_quarter_and_year": "{} {}".format(*utility.get_previous_quarter_and_year(agency.get_quarter(), agency.get_year())),
         "current_quarter_and_year": f"{agency.get_quarter()} {agency.get_year()}",
-        "agency_name": agency.get_name()
+        "agency_name": agency.get_name(),
+        "agency_abbreviation": "SBA",   # NOTE: this is temporarily hard-coded, should be changed to `agency.get_abbreviation()` once the agency name mapping is implemented
+        "goal_change_summary_sentence": text_templates.get_goal_change_summary_sentence(agency)
     }
 
     tpl.render(replacement_map)

--- a/src/output_creation.py
+++ b/src/output_creation.py
@@ -43,6 +43,7 @@ def create_summary_document(template_path, agency):
     Creates a summary document for the passed agency, year and quarter.
 
     :param template_path: The path to the template docx file from which a copy will be made containing relevant data.
+    :param agency: An Agency object representing the agency that a summary report will be created for.
     """
     tpl = DocxTemplate(template_path)
 

--- a/src/output_creation.py
+++ b/src/output_creation.py
@@ -23,8 +23,8 @@ def replace_placeholder_images(tpl):
     :param tpl: A DocxTemplate containing placeholder images.
     """
     placeholder_figure_map = {
-        "Picture 6": "viz/goal_status_q4_2020.png",
-        "Picture 7": "viz/goal_status_q3_2020.png",
+        "Picture 2": "viz/small_multiples_previous.png",
+        "Picture 3": "viz/small_multiples_current.png",
     }
 
     for key, value in placeholder_figure_map.items():

--- a/src/output_creation.py
+++ b/src/output_creation.py
@@ -44,7 +44,8 @@ def create_summary_document(template_path, agency):
         "current_quarter_and_year": f"{agency.get_quarter()} {agency.get_year()}",
         "agency_name": agency.get_name(),
         "agency_abbreviation": "SBA",   # NOTE: this is temporarily hard-coded, should be changed to `agency.get_abbreviation()` once the agency name mapping is implemented
-        "goal_change_summary_sentence": text_templates.get_goal_change_summary_sentence(agency)
+        "goal_change_summary_sentence": text_templates.get_goal_change_summary_sentence(agency),
+        "goal_status_breakdown_bullets": text_templates.get_goal_status_breakdown_bullets(agency)
     }
 
     tpl.render(replacement_map)

--- a/src/output_creation.py
+++ b/src/output_creation.py
@@ -5,6 +5,7 @@ Maps keywords imbedded in template document (keys) to what they will be replaced
 import utility
 import agency
 import text_templates
+import viz
 
 from docx.text.paragraph import Paragraph
 from docxtpl import DocxTemplate
@@ -29,6 +30,14 @@ def replace_placeholder_images(tpl):
     for key, value in placeholder_figure_map.items():
         tpl.replace_pic(key, value)
 
+def create_visuals(agency):
+    """
+    Dynamically creates all of the visualizations needed for the summary report.
+
+    :param agency: An Agency object representing the agency that a summary report will be created for.
+    """
+    viz.create_goal_summary_small_multiples(agency)
+
 def create_summary_document(template_path, agency):
     """
     Creates a summary document for the passed agency, year and quarter.
@@ -37,6 +46,7 @@ def create_summary_document(template_path, agency):
     """
     tpl = DocxTemplate(template_path)
 
+    create_visuals(agency)
     replace_placeholder_images(tpl)
 
     replacement_map = {

--- a/src/output_creation.py
+++ b/src/output_creation.py
@@ -59,4 +59,11 @@ def create_summary_document(template_path, agency):
     }
 
     tpl.render(replacement_map)
-    tpl.save("output.docx")
+
+    try:
+        tpl.save("output.docx")
+    except ValueError as e:
+        if all(keyword in str(e) for keyword in ["Picture", "not found in the docx template"]):    # checking to see if error message contains two keywords indicating picture not found in the docx template
+            raise ValueError(f"{e}. Pictures present in the document are as follows: {', '.join(utility.get_picture_names(tpl))}")
+        else:
+            raise ValueError(e)     # raise raw ValueError

--- a/src/text_templates.py
+++ b/src/text_templates.py
@@ -1,0 +1,33 @@
+"""
+Includes functions that take key information and format it in a client-friendly string that can be used in summary reports.
+"""
+
+import agency
+import utility
+
+def get_goal_change_summary_sentence(agency):
+    """
+    Given a passed agency, returns a sentence summarizing the change in total goal status across the agency from quarter to quarter.
+
+    :param agency: An Agency object representing a CFO Act agency at a given point in time.
+    :return: A string summarizing the quarter-over-quarter goal status change of the passed agency in the format "{number of occurrences} goals {goal status} last quarter to {number of occurrences} goals {goal status} this quarter."
+    """
+    previous_quarter, previous_year = utility.get_previous_quarter_and_year(agency.get_quarter(), agency.get_year())
+
+    current_goal_statuses = agency.get_goal_status_df()["Status"]
+    previous_goal_statuses = agency.get_goal_status_df(quarter=previous_quarter, year=previous_year)["Status"]
+    
+    to_return = ""
+    
+    # loops through each the previous and current goal status lists, accompanying string based on which list is being used
+    for status_list, last_or_this_quarter in zip([previous_goal_statuses, current_goal_statuses], ["last quarter", "this quarter"]):
+        status_strs = []    # list to hold each string uniquely describing goal status
+    
+        for status in status_list.unique():
+            num_status = (status_list == status).sum()  # number of occurrences of given status
+            status_strs.append(f"{num_status} goals {status.lower()}")
+
+        to_return += f"{' and '.join(status_strs)} {last_or_this_quarter} quarter"  # joins each string together with "and" keyword
+        to_return += ' to ' if last_or_this_quarter == 'last quarter' else ''   # adds a connecting word if in the first loop
+        
+    return to_return

--- a/src/text_templates.py
+++ b/src/text_templates.py
@@ -52,18 +52,18 @@ def get_goal_status_breakdown_bullets(agency):
         current_goal_status = agency.get_goal_status(goal_name)
         previous_goal_status = agency.get_goal_status(goal_name, quarter="previous")
 
-        rt.add(str(goal_name), bold=True)   # bolds the goal name at the beginning of the line
-        rt.add(f"'s team identified the status of the goal as {current_goal_status.lower()} this quarter, ")
+        rt.add(str(goal_name), bold=True, font="Roboto")   # bolds the goal name at the beginning of the line
+        rt.add(f"'s team identified the status of the goal as {current_goal_status.lower()} this quarter, ", font="Roboto")
 
         # the next section of the line is conditional based on whether the goal status has stayed the same, progressed or regressed
         if current_goal_status == previous_goal_status:
-            rt.add(f"remaining at the same status as its report of {current_goal_status.lower()} last quarter.")
+            rt.add(f"remaining at the same status as its report of {current_goal_status.lower()} last quarter.", font="Roboto")
         elif utility.goal_is_progressing(current_goal_status, previous_goal_status):
-            rt.add(f"progressing from a status of {previous_goal_status.lower()} last quarter.")
+            rt.add(f"progressing from a status of {previous_goal_status.lower()} last quarter.", font="Roboto")
         else:   # goal is regressing
-            rt.add(f"dropping from a status of {previous_goal_status.lower()} reported last quarter.")
+            rt.add(f"dropping from a status of {previous_goal_status.lower()} reported last quarter.", font="Roboto")
         
         if i != len(goals_list) - 1:
-            rt.add("\a")    # adds a paragraph break following each goal status statement (except for the final one)
+            rt.add("\a", font="Roboto")    # adds a paragraph break following each goal status statement (except for the final one)
 
     return rt

--- a/src/utility.py
+++ b/src/utility.py
@@ -9,6 +9,13 @@ from docx.table import _Cell, Table
 from docx.text.paragraph import Paragraph
 
 import xml.etree.ElementTree as ET
+# A dictionary mapping each goal status to a rank
+STATUS_RANK_MAP = {
+    "Ahead": 4,
+    "On track": 3,
+    "Nearly on track": 2,
+    "Blocked": 1
+}
 
 def iter_block_items(parent):
     """
@@ -70,3 +77,15 @@ def get_picture_names(tpl):
             picture_names.append(elem.attrib["name"])
 
     return picture_names
+def goal_is_progressing(current_status, previous_status):
+    """
+    Returns TRUE if the passed goal is progressing quarter-over-quarter, FALSE otherwise.
+
+    :param current_status: The current status of the goal being assessed.
+    :param previous_status: The previous quarter's status of the goal being assessed.
+    :return: TRUE if the goal is progressing in its status, FALSE otherwise.
+    """
+    try:
+        return STATUS_RANK_MAP[current_status] > STATUS_RANK_MAP[previous_status]
+    except:
+        raise Exception(f"{current_status}, {previous_status}")

--- a/src/utility.py
+++ b/src/utility.py
@@ -9,6 +9,7 @@ from docx.table import _Cell, Table
 from docx.text.paragraph import Paragraph
 
 import xml.etree.ElementTree as ET
+
 # A dictionary mapping each goal status to a rank
 STATUS_RANK_MAP = {
     "Ahead": 4,
@@ -63,6 +64,19 @@ def get_previous_quarter_and_year(quarter, year):
     else:
         return "Q4", year - 1
 
+def goal_is_progressing(current_status, previous_status):
+    """
+    Returns TRUE if the passed goal is progressing quarter-over-quarter, FALSE otherwise.
+
+    :param current_status: The current status of the goal being assessed.
+    :param previous_status: The previous quarter's status of the goal being assessed.
+    :return: TRUE if the goal is progressing in its status, FALSE otherwise.
+    """
+    try:
+        return STATUS_RANK_MAP[current_status] > STATUS_RANK_MAP[previous_status]
+    except:
+        raise Exception(f"{current_status}, {previous_status}")
+
 def get_picture_names(tpl):
     """
     Returns a list of all of the names of the images held within the passed DocxTemplate object. Holds relevance for mapping which images in the template document are to be replaced by auto-generated figures.
@@ -77,15 +91,3 @@ def get_picture_names(tpl):
             picture_names.append(elem.attrib["name"])
 
     return picture_names
-def goal_is_progressing(current_status, previous_status):
-    """
-    Returns TRUE if the passed goal is progressing quarter-over-quarter, FALSE otherwise.
-
-    :param current_status: The current status of the goal being assessed.
-    :param previous_status: The previous quarter's status of the goal being assessed.
-    :return: TRUE if the goal is progressing in its status, FALSE otherwise.
-    """
-    try:
-        return STATUS_RANK_MAP[current_status] > STATUS_RANK_MAP[previous_status]
-    except:
-        raise Exception(f"{current_status}, {previous_status}")

--- a/src/viz.py
+++ b/src/viz.py
@@ -2,6 +2,8 @@
 Guides the creation of visualizations for the summary report from the source data.
 """
 
+import matplotlib
+matplotlib.use('tkagg')
 import matplotlib.pyplot as plt
 import seaborn as sns
 import pandas as pd


### PR DESCRIPTION
This pull request includes all of the framework involved in generating the first page of the summary report and implements it into `create_summary_document()`. The features on the first page of the summary report that are implemented in this pull request are:

- Filling placeholder images with dynamically generated figures (building off the framework established in #7).
- Dynamic generation of summary text based on quarter-over-quarter goal status changes. 

Note that this pull request introduces docxtpl's [`RichText` class](https://docxtpl.readthedocs.io/en/latest/index.html#richtext), used for adding bolded font to only part of a replacement string. 