### PR TITLE
Implement plots on second page of summary report

### DIFF
--- a/src/df_creator.py
+++ b/src/df_creator.py
@@ -52,9 +52,10 @@ def get_challenge_count_by_quarter(df):
     challenge_count_df = None
 
     for challenge in utility.CHALLENGES_LIST:
-        data_df = df.loc[(df[challenge] == "Yes")].astype({challenge:"category"})   # without changing the type of the column, the groupby automatically drops all fields with a count of 0
+        data_df = df.astype({challenge:"category"})   # without changing the type of the column, the groupby automatically drops all fields with a count of 0
 
         data_df = data_df.groupby(["Agency Name", "Fiscal Year", "Quarter", challenge]).size().reset_index().rename(columns={0: "Count"})
+        data_df = data_df.loc[(data_df[challenge] == "Yes")]
         
         # Change column with challenge name to general "Challenge" column, filled with the unique challenge name
         data_df[challenge] = challenge

--- a/src/df_creator.py
+++ b/src/df_creator.py
@@ -41,3 +41,28 @@ def get_recurring_challenges_count(df):
                 })
 
     return pd.DataFrame(data=data)
+
+def get_challenge_count_by_quarter(df):
+    """
+    Returns a DataFrame with the challenge count by quarter for each agency within the passed DataFrame.
+
+    :param df: A DataFrame that resembles either the raw data storage source or a slice of original source.
+    :return: A DataFrame that displays the number of occurrences of a given challenge across each agency in a given quarter and fiscal year.
+    """
+    challenge_count_df = None
+
+    for challenge in utility.CHALLENGES_LIST:
+        data_df = df.loc[(df[challenge] == "Yes")].astype({challenge:"category"})   # without changing the type of the column, the groupby automatically drops all fields with a count of 0
+
+        data_df = data_df.groupby(["Agency Name", "Fiscal Year", "Quarter", challenge]).size().reset_index().rename(columns={0: "Count"})
+        
+        # Change column with challenge name to general "Challenge" column, filled with the unique challenge name
+        data_df[challenge] = challenge
+        data_df = data_df.rename(columns={challenge: "Challenge"})
+        
+        if isinstance(challenge_count_df, pd.core.frame.DataFrame):
+            challenge_count_df = challenge_count_df.append(data_df)
+        else:
+            challenge_count_df = pd.DataFrame(data=data_df)     # initializes the DataFrame if it does not exist yet
+
+    return challenge_count_df.sort_values(["Agency Name", "Fiscal Year", "Quarter"]).reset_index(drop=True)

--- a/src/output_creation.py
+++ b/src/output_creation.py
@@ -27,6 +27,7 @@ def replace_placeholder_images(tpl):
     placeholder_figure_map = {
         "Picture 2": "viz/small_multiples_previous.png",
         "Picture 3": "viz/small_multiples_current.png",
+        "Picture 4": "viz/challenges_reported_bar_chart.png"
     }
 
     for key, value in placeholder_figure_map.items():
@@ -39,6 +40,7 @@ def create_visuals(agency):
     :param agency: An Agency object representing the agency that a summary report will be created for.
     """
     viz.create_goal_summary_small_multiples(agency)
+    viz.create_challenges_reported_in_quarter(agency)
 
 def create_summary_document(template_path, agency):
     """

--- a/src/output_creation.py
+++ b/src/output_creation.py
@@ -27,7 +27,8 @@ def replace_placeholder_images(tpl):
     placeholder_figure_map = {
         "Picture 2": "viz/small_multiples_previous.png",
         "Picture 3": "viz/small_multiples_current.png",
-        "Picture 4": "viz/challenges_reported_bar_chart.png"
+        "Picture 4": "viz/challenges_reported_bar_chart.png",
+        "Picture 5": "viz/challenges_area_chart.png"
     }
 
     for key, value in placeholder_figure_map.items():
@@ -41,6 +42,7 @@ def create_visuals(agency):
     """
     viz.create_goal_summary_small_multiples(agency)
     viz.create_challenges_reported_in_quarter(agency)
+    viz.create_challenges_area_chart(agency)
 
 def create_summary_document(template_path, agency):
     """

--- a/src/viz.py
+++ b/src/viz.py
@@ -89,3 +89,41 @@ def create_goal_summary_small_multiples(agency, dir=DEFAULT_DIRECTORY, names=["s
         fig.set_size_inches(12, 8)
         fig.savefig(f"{dir}{filename}", bbox_inches='tight')
         plt.clf()  # clears plot
+
+def create_challenges_reported_in_quarter(agency, dir=DEFAULT_DIRECTORY, name="challenges_reported_bar_chart"):
+    """
+    Creates a graph representing the challenges reported in a quarter and saves it to a specified name and directory.
+
+    :param agency: The Agency object from which a quarterly challenges reported plot will be created.
+    :param dir: The directory to which the figure will be saved to.
+    :param name: The file name that the figure will be saved to.
+    """
+    # Retrieve DataFrame, filter for only this quarter
+    challenge_count_df = df_creator.get_challenge_count_by_quarter(agency.get_agency_df())
+    challenge_count_df = challenge_count_df.loc[(challenge_count_df["Quarter"] == agency.get_quarter()) & (challenge_count_df["Fiscal Year"] == agency.get_year())].sort_values(by="Count", ascending=False)
+
+    font = {
+        'family' : 'sans-serif',
+        'size'   : 24
+    }
+
+    plt.rc('font', **font)
+
+    # Creates barplot
+    sns.barplot(x="Challenge", y="Count", data=challenge_count_df, ci=None, palette=["grey" for i in range(len(challenge_count_df))])
+    
+    fig = plt.gcf()
+    ax = plt.gca()
+
+    # Editing the display of the plot
+    plt.suptitle(f"Challenges Reported across SBA APGs in Q4 2020")
+    plt.xlabel("")  # removes x label
+    plt.xticks(rotation=45, ha="right", fontsize=24)
+    ax.margins(y=0)
+    plt.yticks(ticks=[i for i in range(len(agency.get_goals()) + 1)], fontsize=24)
+    ax.set_ylabel(ax.yaxis.get_label().get_text(), fontdict=font)   # sets the size of the category label on the y axis
+
+    # Exporting figure
+    fig.set_size_inches(12, 8)
+    fig.savefig(f"{dir}{name}", bbox_inches="tight")
+    plt.clf()

--- a/src/viz.py
+++ b/src/viz.py
@@ -86,9 +86,8 @@ def create_goal_summary_small_multiples(agency, dir=DEFAULT_DIRECTORY, names=["s
         ax.set_ylabel(ax.yaxis.get_label().get_text(), fontdict=font)   # sets the size of the category label on the y axis
         
         # Exporting figure
-        fig.set_size_inches(12, 8)
-        fig.savefig(f"{dir}{filename}", bbox_inches='tight')
-        plt.clf()  # clears plot
+        fig.set_size_inches(12, 8)   # saved image is larger, of higher quality
+        __save_figure(fig, dir, filename)
 
 def create_challenges_reported_in_quarter(agency, dir=DEFAULT_DIRECTORY, name="challenges_reported_bar_chart"):
     """
@@ -124,6 +123,16 @@ def create_challenges_reported_in_quarter(agency, dir=DEFAULT_DIRECTORY, name="c
     ax.set_ylabel(ax.yaxis.get_label().get_text(), fontdict=font)   # sets the size of the category label on the y axis
 
     # Exporting figure
-    fig.set_size_inches(12, 8)
+    fig.set_size_inches(12, 8)   # saved image is larger, of higher quality
+    __save_figure(fig, dir, name)
+
+def __save_figure(fig, dir, name):
+    """
+    Saves the passed figure to the passed directory path and name.
+
+    :param fig: The figure to be saved.
+    :param dir: The directory to which the figure will be saved to.
+    :param name: The file name that the figure will be saved to.
+    """
     fig.savefig(f"{dir}{name}", bbox_inches="tight")
-    plt.clf()
+    plt.clf()   # clears plot

--- a/src/viz.py
+++ b/src/viz.py
@@ -126,6 +126,42 @@ def create_challenges_reported_in_quarter(agency, dir=DEFAULT_DIRECTORY, name="c
     fig.set_size_inches(12, 8)   # saved image is larger, of higher quality
     __save_figure(fig, dir, name)
 
+def create_challenges_area_chart(agency, dir=DEFAULT_DIRECTORY, name="challenges_area_chart"):
+    """
+    Creates an area chart showing the cumulative amount of challenges reported in each category.
+
+    :param agency: The Agency object from which a challenges area chart will be created.
+    :param dir: The directory to which the figure will be saved to.
+    :param name: The file name that the figure will be saved to.
+    """
+    # Retrieve DataFrame, sort values in chronological order
+    challenge_count_df = df_creator.get_challenge_count_by_quarter(agency.get_agency_df())
+    challenge_count_df.sort_values(by=["Fiscal Year", "Quarter"])
+
+    data = {}
+
+    # Create data entry of cumulative sum for each challenge. Cumulative sum is in chronological order, dating from the furthest back quarter reported to the most recent
+    for challenge in utility.CHALLENGES_LIST:
+        cumsum = list(challenge_count_df.loc[challenge_count_df["Challenge"] == challenge]["Count"].cumsum())
+        data[challenge] = cumsum
+        
+    # Create area plot from cumulative sum data
+    pd.DataFrame(data).plot.area(stacked=False)
+
+    fig = plt.gcf()
+    ax = plt.gca()
+
+    # Editing the display of the plot
+    quarter_list = [f"{quarter}" for year in challenge_count_df["Fiscal Year"].unique() for quarter in challenge_count_df["Quarter"].unique()]  # a list of all quarters stored in DataFrame
+    plt.xticks([i for i in range(len(quarter_list))], quarter_list, fontsize=24)
+    plt.yticks(fontsize=24)
+    ax.grid(False)
+    plt.legend(prop={'size': 20})
+
+    # Exporting figure
+    fig.set_size_inches(12, 8)
+    __save_figure(plt.gcf(), dir, name)
+
 def __save_figure(fig, dir, name):
     """
     Saves the passed figure to the passed directory path and name.


### PR DESCRIPTION
This pull request includes functions for creating and saving the plots as well as the pipeline to place those plots into the summary report once they are created. 

Plots included in this pull request are:

- Bar chart that displays the count of each unique challenge in the quarter being reported on.
- Area chart that displays the cumulative count of each challenge reported over all quarters.