### PR TITLE
Add list of challenges to APG breakdown page

### DIFF
--- a/src/agency.py
+++ b/src/agency.py
@@ -133,3 +133,14 @@ class Agency():
             return self.get_agency_df().loc[(self.get_agency_df()["Goal Name"] == goal_name) & (self.get_agency_df()["Fiscal Year"] == year) & (self.get_agency_df()["Quarter"] == quarter), "Status"].iloc[0]
         except IndexError:  # if the passed goal name is not held within the agency
             return None
+
+    def get_challenges(self, goal_name):
+        """
+        Returns a list of the challenges reported for the passed goal name.
+
+        :param goal_name: The name of the APG from which the challenges reported will be returned.
+        :return: A list of the challenges reported by the passed goal team.
+        """
+        apg_row = self.get_agency_df().loc[(self.get_agency_df()["Quarter"] == self.get_quarter()) & (self.get_agency_df()["Fiscal Year"] == self.get_year()) & (self.get_agency_df()["Goal Name"] == goal_name)]
+        
+        return apg_row[utility.CHALLENGES_LIST].columns[(apg_row[utility.CHALLENGES_LIST] == "Yes").all()].tolist()     # list of challenge columns that are in the affirmative

--- a/src/output_creation.py
+++ b/src/output_creation.py
@@ -109,7 +109,8 @@ def create_summary_document(template_path, agency, output_dir="../"):
             "apg_name": apg,
             "speedometer_text": text_templates.get_speedometer_summary_text(agency, apg),
             "blockers_text": text_templates.get_blockers_text(agency, apg),
-            "group_assistance_text": text_templates.get_group_help_text(agency, apg)
+            "group_assistance_text": text_templates.get_group_help_text(agency, apg),
+            "challenge_bullets": text_templates.get_apg_challenges_bullets(agency, apg)
         }
 
         # Fill placeholders of image tags

--- a/src/text_templates.py
+++ b/src/text_templates.py
@@ -192,3 +192,13 @@ def get_group_help_text(agency, apg_name):
             rt.add(f" {value}", font="Roboto")
 
     return rt
+
+def get_apg_challenges_bullets(agency, apg_name):
+    """
+    Returns a RichText object listing out the challenges reported by the APG goal team during the reported quarter, which is capable of being represented as a bulleted list. NOTE: The returned RichText object itself does not return a bulleted list, but each paragraph renders as a bullet when placed in a bulleted list in a template document.
+
+    :param agency: An Agency object representing a CFO Act agency at a given point in time.
+    :param apg_name: The name of the APG whose status will be summarized.
+    :return: A RichText object object listing out the challenges reported by the APG goal team during the reported quarter, which is capable of being represented as a bulleted list. 
+    """
+    rt = RichText()

--- a/src/text_templates.py
+++ b/src/text_templates.py
@@ -202,3 +202,16 @@ def get_apg_challenges_bullets(agency, apg_name):
     :return: A RichText object object listing out the challenges reported by the APG goal team during the reported quarter, which is capable of being represented as a bulleted list. 
     """
     rt = RichText()
+
+    challenges_list = agency.get_challenges(apg_name)
+
+    # Add every challenge in list to RichText object
+    for i in range(len(challenges_list)):
+        challenge = challenges_list[i]
+
+        rt.add(f"{challenge}", font="Roboto")
+
+        if i != len(challenges_list) - 1:
+            rt.add("\a")    # adds a paragraph break following each challenge (except for the final one)
+
+    return rt


### PR DESCRIPTION
Rendered in the form of a bulleted list. Also introduces the `get_challenges()` method to the Agency class, which retrieves a list of challenges for the passed APG.