### PR TITLE
Handle error in creating area chart when some challenges were never reported

### DIFF
--- a/src/df_creator.py
+++ b/src/df_creator.py
@@ -56,7 +56,14 @@ def get_challenge_count_by_quarter(df):
         data_df = df.astype({challenge:"category"})   # without changing the type of the column, the groupby automatically drops all fields with a count of 0
 
         data_df = data_df.groupby(["Agency Name", "Fiscal Year", "Quarter", challenge]).size().reset_index().rename(columns={0: "Count"})
-        data_df = data_df.loc[(data_df[challenge] == "Yes")]
+
+        # Error handling: groupby will not create any rows of "Yes" values if the agency never identified the given challenge. Checking to see if data_df only contains unchecked challenges
+        if len(data_df.loc[(data_df[challenge] == "Yes")]) == 0 and len(data_df.loc[(data_df[challenge] == "Off")]) == len(data_df):
+            # Converts the count of the unchecked challenges to its inverse: a count of all the times the challenge was checked.
+            data_df[challenge] = "Yes"
+            data_df["Count"] = 0
+        else:
+            data_df = data_df.loc[(data_df[challenge] == "Yes")]
         
         # Change column with challenge name to general "Challenge" column, filled with the unique challenge name
         data_df[challenge] = challenge

--- a/src/viz.py
+++ b/src/viz.py
@@ -144,8 +144,10 @@ def create_challenges_area_chart(agency, dir=DEFAULT_DIRECTORY, name="challenges
 
     # Create data entry of cumulative sum for each challenge. Cumulative sum is in chronological order, dating from the furthest back quarter reported to the most recent
     for challenge in CHALLENGES_LIST:
-        cumsum = list(challenge_count_df.loc[challenge_count_df["Challenge"] == challenge]["Count"].cumsum())
-        data[challenge] = cumsum
+        challenge_df_slice = challenge_count_df.loc[challenge_count_df["Challenge"] == challenge]   # a slice of the challenge df with only the current challenge
+        if challenge_df_slice["Count"].sum() != 0:  # only include challenges that were identified by the challenge team
+            cumsum = list(challenge_df_slice["Count"].cumsum())
+            data[challenge] = cumsum
         
     # Create area plot from cumulative sum data
     pd.DataFrame(data).plot.area(stacked=False)


### PR DESCRIPTION
This pull request makes two notable improvements:
- Adds rows for challenges that were never selected in `get_challenge_count_by_quarter()` (these rows were unknowingly omitted in the previous implementation).
- Removes challenges that were never selected from the legend in the area plot.

Resolves #36.