### PR TITLE
Correct bug preventing display of "On track" statuses in small multiples plots

### DIFF
--- a/src/viz.py
+++ b/src/viz.py
@@ -39,7 +39,7 @@ def create_goal_summary_small_multiples(agency, dir=DEFAULT_DIRECTORY, names=["s
 
     # Create ordered hierarchy of statuses
     status_ordered = CategoricalDtype(
-        ['Blocked', 'On Track', 'Ahead'], 
+        ['Blocked', 'On track', 'Ahead'], 
         ordered=True
     )
 


### PR DESCRIPTION
Bug caused by the misspelling of "On track" in small multiples creator function compared to the way it is spelled in the dummy data, which makes the case for making fields like this constants.

Resolves #38.