### PR TITLE
Change running `main.py` to create summary reports for all CFO Act agencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 .ipynb_checkpoints/
 viz/
+output/*

--- a/src/agency.py
+++ b/src/agency.py
@@ -2,7 +2,7 @@
 Holds definition of Agency class and its associated methods.
 """
 
-from constants import CHALLENGES_LIST
+from constants import CHALLENGES_LIST, AGENCY_NAME_TO_ABBREVIATION
 import utility
 
 import pandas as pd
@@ -25,7 +25,7 @@ class Agency():
         self.name = name
         self.agency_df = self.get_df().loc[self.get_df()["Agency Name"] == self.get_name()]  # a DataFrame only containing data relevant to the agency that the object represents
         self.apgs = list(self.get_agency_df()["Goal Name"].unique())
-        self.abbreviation = ""  # the abbreviation of the passed agency
+        self.abbreviation = AGENCY_NAME_TO_ABBREVIATION[name]   # the abbreviation of the passed agency
         self.current_quarter = current_quarter 
         self.current_year = current_year
 

--- a/src/agency.py
+++ b/src/agency.py
@@ -2,7 +2,7 @@
 Holds definition of Agency class and its associated methods.
 """
 
-from constants import CHALLENGES_LIST, AGENCY_NAME_TO_ABBREVIATION
+from constants import CHALLENGES_LIST, AGENCY_NAME_TO_ABBREVIATION, AGENCY_ABBREVIATION_TO_NAME
 import utility
 
 import pandas as pd
@@ -17,15 +17,22 @@ class Agency():
         Constructor method; creates a Agency object initialized with the basic attributes of a agency being reported on.
 
         :param df: The central DataFrame that information will be pulled from - includes the data for all agencies, not just the agency that the object represents.
-        :param name: The name of the agency that this object represents.
+        :param name: The name of the agency that this object represents. Takes either an abbreviation or a full agency name.
         :param current_quarter: The quarter that this agency will be reporting on.
         :param current_year: The year that this agency will be reporting on. 
         """
+        if name in AGENCY_ABBREVIATION_TO_NAME.keys():  # if name is an abbreviation:
+            self.name = AGENCY_ABBREVIATION_TO_NAME[name]
+            self.abbreviation = name
+        elif name in AGENCY_NAME_TO_ABBREVIATION.keys():    # if name is a full agency name
+            self.name = name
+            self.abbreviation = AGENCY_NAME_TO_ABBREVIATION[name]
+        else:
+            raise ValueError(f"\"{name}\" is neither a valid agency abbreviation nor a full agency name of one of the 24 CFO act agencies.")
+
         self.df = df
-        self.name = name
-        self.agency_df = self.get_df().loc[self.get_df()["Agency Name"] == self.get_name()]  # a DataFrame only containing data relevant to the agency that the object represents
+        self.agency_df = self.get_df().loc[self.get_df()["Agency Name"] == self.get_abbreviation()]  # a DataFrame only containing data relevant to the agency that the object represents
         self.apgs = list(self.get_agency_df()["Goal Name"].unique())
-        self.abbreviation = AGENCY_NAME_TO_ABBREVIATION[name]   # the abbreviation of the passed agency
         self.current_quarter = current_quarter 
         self.current_year = current_year
 

--- a/src/constants.py
+++ b/src/constants.py
@@ -35,7 +35,6 @@ AGENCY_NAME_TO_ABBREVIATION = {
     "Social Security Administration": "SSA",
     "General Services Administration": "GSA",
     "National Science Foundation": "NSF",
-    "Nuclear Regulatory Commission": "NRC",
     "Office of Personnel Management": "OPM",
     "Small Business Administration": "SBA"
 }

--- a/src/constants.py
+++ b/src/constants.py
@@ -12,3 +12,32 @@ CHALLENGES_LIST = ["Hiring", "Competing deadlines", "Legislation", "Lack of rese
 
 SUMMARY_TEMPLATE_PATH = "src/resources/templates/Summary_Report_Template.docx"
 APG_BREAKDOWN_TEMPLATE_PATH = "src/resources/templates/APG_Summary_Template.docx"
+
+AGENCY_NAME_TO_ABBREVIATION = {
+    "Department of Agriculture": "USDA", 
+    "Department of Commerce": "DOC",
+    "Department of Defense": "DOD",
+    "Department of Education": "ED",
+    "Department of Energy": "DOE",
+    "Department of Health and Human Services": "HHS",
+    "Department of Homeland Security": "DHS",
+    "Department of Housing and Urban Development": "HUD",
+    "Department of Interior": "DOI",
+    "Department of Justice": "DOJ",
+    "Department of Labor": "DOL",
+    "Department of State": "DOS",
+    "Department of Transportation": "DOT",
+    "Department of Treasury": "USDT",
+    "Department of Veterans Affairs": "VA",
+    "Environmental Protection Agency": "EPA",
+    "National Aeronautics and Space Administration": "NASA",
+    "Agency for International Development": "USAID",
+    "Social Security Administration": "SSA",
+    "General Services Administration": "GSA",
+    "National Science Foundation": "NSF",
+    "Nuclear Regulatory Commission": "NRC",
+    "Office of Personnel Management": "OPM",
+    "Small Business Administration": "SBA"
+}
+
+AGENCY_ABBREVIATION_TO_NAME = {value: key for key, value in AGENCY_NAME_TO_ABBREVIATION.items()}

--- a/src/main.py
+++ b/src/main.py
@@ -5,7 +5,5 @@ import output_creation
 import agency
 import pandas as pd
 
-# NOTE: The current implementation below is for development purposes. When this project is in production, the implementation below should create summary report documents for each CFO act agency with the most updated cover sheet data.
 if __name__ == "__main__":
-    sba = agency.Agency(pd.read_csv("../dummy_cover_sheet_data.csv"), "SBA", "Q4", 2020)    # created for debugging in development
-    output_creation.create_summary_document(sba)
+    pass

--- a/src/main.py
+++ b/src/main.py
@@ -2,8 +2,14 @@
 File to be run to generate summary reports for the most recent quarter
 """
 import output_creation
-import agency
+from agency import Agency
 import pandas as pd
 
+from constants import AGENCY_ABBREVIATION_TO_NAME
+
 if __name__ == "__main__":
-    pass
+    for agency_abbreviation in AGENCY_ABBREVIATION_TO_NAME.keys():
+        file_name = f"{agency_abbreviation}_Summary"
+        agency = Agency(pd.read_csv("../dummy_cover_sheet_data.csv"), agency_abbreviation, "Q4", 2020)
+        output_creation.create_summary_document(agency, file_name)
+        print(file_name, "created")

--- a/src/output_creation.py
+++ b/src/output_creation.py
@@ -80,7 +80,7 @@ def create_summary_document(agency, output_dir="../"):
         "previous_quarter_and_year": "{} {}".format(*utility.get_previous_quarter_and_year(agency.get_quarter(), agency.get_year())),
         "current_quarter_and_year": f"{agency.get_quarter()} {agency.get_year()}",
         "agency_name": agency.get_name(),
-        "agency_abbreviation": "SBA",   # NOTE: this is temporarily hard-coded, should be changed to `agency.get_abbreviation()` once the agency name mapping is implemented
+        "agency_abbreviation": agency.get_abbreviation(),
         "goal_change_summary_sentence": text_templates.get_goal_change_summary_sentence(agency),
         "goal_status_breakdown_bullets": text_templates.get_goal_status_breakdown_bullets(agency),
         "recur_challenge_1": recurring_challenges_df.iloc[0]["Challenge"].lower(),

--- a/src/output_creation.py
+++ b/src/output_creation.py
@@ -62,7 +62,7 @@ def create_visuals(agency):
         goal = goals[i]
         viz.create_goal_status_over_time(agency, goal, name=f"goal_status_over_time_{i}")
 
-def create_summary_document(agency, output_filename, output_dir="../"):
+def create_summary_document(agency, output_filename, output_dir="output/summary_reports/"):
     """
     Creates a summary document for the passed agency, year and quarter.
 
@@ -136,6 +136,10 @@ def create_summary_document(agency, output_filename, output_dir="../"):
             f"speedometer_image_{i}": InlineImage(tpl, image_descriptor=f"viz/speedometers/speedometer_{formatted_goal_status}.png", width=Inches(3)),   # width of 3 inches seems to be sweet spot for 2-column table
             f"goal_status_over_time_{i}": InlineImage(tpl, image_descriptor=f"viz/goal_status_over_time_{i}.png", width=Inches(3))
         })
+
+    # Creates output directories if they do not already exist
+    if not os.path.isdir(output_dir):
+        os.makedirs(output_dir)  
 
     try:
         tpl.save(f"{output_dir}{output_filename}.docx")

--- a/src/output_creation.py
+++ b/src/output_creation.py
@@ -62,11 +62,12 @@ def create_visuals(agency):
         goal = goals[i]
         viz.create_goal_status_over_time(agency, goal, name=f"goal_status_over_time_{i}")
 
-def create_summary_document(agency, output_dir="../"):
+def create_summary_document(agency, output_filename, output_dir="../"):
     """
     Creates a summary document for the passed agency, year and quarter.
 
     :param agency: An Agency object representing the agency that a summary report will be created for.
+    :param output_filename: The filename to which the output file will be save. Excluding file extension (.docx).
     :param output_dir: The directory to which the output file will be saved to.
     """
     tpl = DocxTemplate(SUMMARY_TEMPLATE_PATH)
@@ -137,7 +138,7 @@ def create_summary_document(agency, output_dir="../"):
         })
 
     try:
-        tpl.save(f"{output_dir}output.docx")
+        tpl.save(f"{output_dir}{output_filename}.docx")
     except ValueError as e:
         if all(keyword in str(e) for keyword in ["Picture", "not found in the docx template"]):    # checking to see if error message contains two keywords indicating picture not found in the docx template
             raise ValueError(f"{e}. Pictures present in the document are as follows: {', '.join(utility.get_picture_names(tpl))}")

--- a/src/testing.py
+++ b/src/testing.py
@@ -7,4 +7,4 @@ import pandas as pd
 
 if __name__ == "__main__":
     sba = agency.Agency(pd.read_csv("../dummy_cover_sheet_data.csv"), "SBA", "Q4", 2020)
-    output_creation.create_summary_document(sba)
+    output_creation.create_summary_document(sba, "SBA_output")

--- a/src/testing.py
+++ b/src/testing.py
@@ -1,0 +1,11 @@
+"""
+File to be run to generate summary reports for the most recent quarter
+"""
+import output_creation
+import agency
+import pandas as pd
+
+# NOTE: The current implementation below is for development purposes. When this project is in production, the implementation below should create summary report documents for each CFO act agency with the most updated cover sheet data.
+if __name__ == "__main__":
+    sba = agency.Agency(pd.read_csv("../dummy_cover_sheet_data.csv"), "SBA", "Q4", 2020)    # created for debugging in development
+    output_creation.create_summary_document(sba)

--- a/src/testing.py
+++ b/src/testing.py
@@ -5,7 +5,6 @@ import output_creation
 import agency
 import pandas as pd
 
-# NOTE: The current implementation below is for development purposes. When this project is in production, the implementation below should create summary report documents for each CFO act agency with the most updated cover sheet data.
 if __name__ == "__main__":
-    sba = agency.Agency(pd.read_csv("../dummy_cover_sheet_data.csv"), "SBA", "Q4", 2020)    # created for debugging in development
+    sba = agency.Agency(pd.read_csv("../dummy_cover_sheet_data.csv"), "SBA", "Q4", 2020)
     output_creation.create_summary_document(sba)

--- a/src/viz.py
+++ b/src/viz.py
@@ -59,7 +59,7 @@ def create_goal_summary_small_multiples(agency, dir=DEFAULT_DIRECTORY, names=["s
     for quarter, year, filename in zip(quarters, years, names):
         # Initializes DataFrame as slice of main DataFrame that relates to the agency, fiscal year and quarter being analyzed in this loop
         quarter_statuses_df = goal_stauts_count_df.loc[
-            (goal_stauts_count_df["Agency Name"] == agency.get_name()) & 
+            (goal_stauts_count_df["Agency Name"] == agency.get_abbreviation()) & 
             (goal_stauts_count_df["Fiscal Year"] == year) & 
             (goal_stauts_count_df["Quarter"] == quarter)
         ].reset_index(drop=True)

--- a/src/viz.py
+++ b/src/viz.py
@@ -229,4 +229,4 @@ def __save_figure(fig, dir, name):
     :param name: The file name that the figure will be saved to.
     """
     fig.savefig(f"{dir}{name}", bbox_inches="tight")
-    plt.clf()   # clears plot
+    plt.close(fig)


### PR DESCRIPTION
As requested in #31, the implementation of `main.py` prior to this pull request was moved to a new file, `testing.py`, that will be expanded for further development/testing capabilities. **`testing.py` may now be used just as `main.py` was before, whereas running `main.py` resembles the output that is expected in production.**

Some important features/changes to note in this pull request include:
- The agency names/abbreviations used to create the summary reports are held in the `AGENCY_NAME_TO_ABBREVIATION` constant.
- The `Agency` class has been changed to accept either a full agency name *or* its abbreviation as an argument and dynamically determines whether it has received a full name or an abbreviation.

Resolves #33.