### PR TITLE
Correct error in writing goal status bullets

### DIFF
--- a/src/objects/agency.py
+++ b/src/objects/agency.py
@@ -162,3 +162,20 @@ class Agency():
             quarter, year = utility.get_previous_quarter_and_year(self.get_quarter(), self.get_year())
 
         return self.get_agency_df().loc[(self.get_agency_df()["Quarter"] == quarter) & (self.get_agency_df()["Fiscal Year"] == year) & (self.get_agency_df()["Goal Name"] == goal_name)]
+
+    def __handle_year_quarter_input(self, year, quarter):
+        """
+        Handles input values of year and quarter and returns either the raw values or machine-readable interpretations of input.
+
+        :param year: The year from which to retrieve goal status. Defaults to the year that the object represents.
+        :param quarter: The quarter from which to retrieve goal status. Defaults to the quarter that the object represents. "previous" returns the data only from the previous quarter.
+        :return: A formatted year followed by a formatted quarter.
+        """
+        if not year:
+            year = self.get_year()
+        if not quarter:
+            quarter = self.get_quarter()
+        elif quarter == "previous":
+            quarter, year = utility.get_previous_quarter_and_year(self.get_quarter(), self.get_year())
+
+        return year, quarter

--- a/src/objects/agency.py
+++ b/src/objects/agency.py
@@ -160,11 +160,11 @@ class Agency():
         :param quarter: The quarter from which to retrieve goal status. Defaults to the quarter that the object represents. "previous" returns the data only from the previous quarter.
         :return: A formatted year followed by a formatted quarter.
         """
-        if not year:
+        if not year:    # assigns current year if no year is specified
             year = self.get_year()
-        if not quarter:
+        if not quarter:     # assigns current quarter if no quarter is specified
             quarter = self.get_quarter()
-        elif quarter == "previous":
+        elif quarter == "previous":     # if quarter is "previous", then the previous year and quarter combination is assigned
             quarter, year = utility.get_previous_quarter_and_year(self.get_quarter(), self.get_year())
 
         return year, quarter

--- a/src/objects/agency.py
+++ b/src/objects/agency.py
@@ -105,13 +105,7 @@ class Agency():
         :param quarter: The quarter from which to retrieve goal status. Defaults to the quarter that the object represents. "all" returns the data from all years and quarters. "previous" returns the data only from the previous quarter.
         :return: A DataFrame mapping each APG to its goal status across the specified year and quarters.
         """
-        if not year:
-            year = self.get_year()
-
-        if not quarter:
-            quarter = self.current_quarter
-        elif quarter == "previous":
-            quarter, year = utility.get_previous_quarter_and_year(self.get_quarter(), self.get_year())
+        year, quarter = self.__handle_year_quarter_input(year, quarter)
 
         conditional = pd.Series(data=[True for i in range(len(self.get_agency_df()))], index=self.get_agency_df().index)     # defaults to all rows
         
@@ -154,12 +148,7 @@ class Agency():
         :param quarter: The quarter from which to retrieve goal status. Defaults to the quarter that the object represents.
         :return: A single row of a DataFrame containing the data retrieved for the passed goal for the current quarter.
         """
-        if not year:
-            year = self.get_year()
-        if not quarter:
-            quarter = self.get_quarter()
-        elif quarter == "previous":
-            quarter, year = utility.get_previous_quarter_and_year(self.get_quarter(), self.get_year())
+        year, quarter = self.__handle_year_quarter_input(year, quarter)
 
         return self.get_agency_df().loc[(self.get_agency_df()["Quarter"] == quarter) & (self.get_agency_df()["Fiscal Year"] == year) & (self.get_agency_df()["Goal Name"] == goal_name)]
 

--- a/src/objects/agency.py
+++ b/src/objects/agency.py
@@ -131,15 +131,8 @@ class Agency():
         :param year: The year from which to retrieve goal status. Defaults to the year that the object represents.
         :param quarter: The quarter from which to retrieve goal status. Defaults to the quarter that the object represents. "previous" returns the data only from the previous quarter.
         """
-        if not year:
-            year = self.get_year()
-        if not quarter:
-            quarter = self.get_quarter()
-        elif quarter == "previous":
-            quarter, year = utility.get_previous_quarter_and_year(self.get_quarter(), self.get_year())
-
         try:
-            return self.get_apg_row(goal_name)["Status"].iloc[0]
+            return self.get_apg_row(goal_name, year=year, quarter=quarter)["Status"].iloc[0]
         except IndexError:  # if the passed goal name is not held within the agency
             return None
 
@@ -152,11 +145,20 @@ class Agency():
         """
         return self.get_apg_row(goal_name)[CHALLENGES_LIST].columns[(self.get_apg_row(goal_name)[CHALLENGES_LIST] == "Yes").all()].tolist()     # list of challenge columns that are in the affirmative
 
-    def get_apg_row(self, goal_name):
+    def get_apg_row(self, goal_name, year=None, quarter=None):
         """
         Returns a single row of a DataFrame containing the data retrieved for the passed goal for the current quarter.
 
         :param goal_name: The name of the APG from which the challenges reported will be returned.
+        :param year: The year from which to retrieve goal status. Defaults to the year that the object represents.
+        :param quarter: The quarter from which to retrieve goal status. Defaults to the quarter that the object represents.
         :return: A single row of a DataFrame containing the data retrieved for the passed goal for the current quarter.
         """
-        return self.get_agency_df().loc[(self.get_agency_df()["Quarter"] == self.get_quarter()) & (self.get_agency_df()["Fiscal Year"] == self.get_year()) & (self.get_agency_df()["Goal Name"] == goal_name)]
+        if not year:
+            year = self.get_year()
+        if not quarter:
+            quarter = self.get_quarter()
+        elif quarter == "previous":
+            quarter, year = utility.get_previous_quarter_and_year(self.get_quarter(), self.get_year())
+
+        return self.get_agency_df().loc[(self.get_agency_df()["Quarter"] == quarter) & (self.get_agency_df()["Fiscal Year"] == year) & (self.get_agency_df()["Goal Name"] == goal_name)]

--- a/src/output/text/text_templates.py
+++ b/src/output/text/text_templates.py
@@ -59,7 +59,7 @@ def get_goal_status_breakdown_bullets(agency):
 
         # the next section of the line is conditional based on whether the goal status has stayed the same, progressed or regressed
         if current_goal_status == previous_goal_status:
-            rt.add(f"remaining consistent at its reported status of {current_goal_status.lower()} last quarter.", font="Roboto")
+            rt.add(f"remaining consistent at its reported status of {previous_goal_status.lower()} last quarter.", font="Roboto")
         elif utility.goal_is_progressing(current_goal_status, previous_goal_status):
             rt.add(f"progressing from a status of {previous_goal_status.lower()} last quarter.", font="Roboto")
         else:   # goal is regressing


### PR DESCRIPTION
Since the issue stemmed from the quarter and year not being properly processed within the Agency class, this pull request includes a utility method to universally handle input of year and quarter in the agency class. This pull request also includes a fix to the use of current goal status instead of previous goal status in one case in the text template function.

Resolves #44.