### PR TITLE
Implement handling of "Nearly on track" status in goal status over time plot

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -2,10 +2,10 @@
 A dictionary mapping each goal status to a rank
 """
 STATUS_RANK_MAP = {
-    "Ahead": 4,
-    "On track": 3,
-    "Nearly on track": 2,
-    "Blocked": 1
+    "Ahead": 3,
+    "On track": 2,
+    "Nearly on track": 1,
+    "Blocked": 0
 }
 
 CHALLENGES_LIST = ["Hiring", "Competing deadlines", "Legislation", "Lack of research", "Unclear guidance", "Unavailable data"]

--- a/src/output/viz/viz.py
+++ b/src/output/viz/viz.py
@@ -191,6 +191,7 @@ def create_goal_status_over_time(agency, apg_name, dir=DEFAULT_DIRECTORY, name="
     # Lines dividing goal statuses
     ax.axhline(0.5, color="white")
     ax.axhline(1.5, color="white")
+    ax.axhline(2.5, color="white")
 
     # Lines dividing fiscal years
     ax.axvline(3.5, color="white", linestyle="--", dashes=[6,9])

--- a/src/output/viz/viz.py
+++ b/src/output/viz/viz.py
@@ -207,7 +207,7 @@ def create_goal_status_over_time(agency, apg_name, dir=DEFAULT_DIRECTORY, name="
     y_ticks  = [item[0] for item in sorted(STATUS_RANK_MAP.items(), key=lambda item: item[1])]  # orders keys based on their values in ascending order
     plt.yticks(np.arange(len(y_ticks)), y_ticks, fontsize=24)     # restore string status names, overwrite numerical ranks
 
-    ax.margins(y=0.25)
+    ax.margins(y=0.15)
     ax.grid(False)  # turns off the seaborn plot
 
     # Exporting figure

--- a/src/output/viz/viz.py
+++ b/src/output/viz/viz.py
@@ -11,7 +11,7 @@ from pandas.api.types import CategoricalDtype
 import numpy as np
 import os
 
-from src.constants import CHALLENGES_LIST
+from src.constants import CHALLENGES_LIST, STATUS_RANK_MAP
 import src.utility as utility
 import src.output.data.df_creator as df_creator
 
@@ -197,21 +197,13 @@ def create_goal_status_over_time(agency, apg_name, dir=DEFAULT_DIRECTORY, name="
     ax.axvline(7.5, color="white", linestyle="--", dashes=[6,9])
     ax.axvline(11.5, color="white", linestyle="--", dashes=[6,9])
 
-    # Create ordered hierarchy of statuses
-    # TODO: Remove this map, implement map listed as constant in utility.py. That map also includes a key of "Nearly on track", which requires further implementation of this function.
-    status_rank_map = {
-        "Ahead": 2,
-        "On track": 1,
-        "Blocked": 0
-    }
-
-    status_ranked = pd.Series([status_rank_map[status] for status in list(apg_status_df["Status"])])    # List of numerical ranking of APG statuses in chronological order, needed to correctly order statuses on y-axis
+    status_ranked = pd.Series([STATUS_RANK_MAP[status] for status in list(apg_status_df["Status"])])    # List of numerical ranking of APG statuses in chronological order, needed to correctly order statuses on y-axis
 
     # Create plot
     plt.plot(apg_status_df["Quarter/Year"], status_ranked, marker="o", markersize=16)
     plt.suptitle("Goal Status Over Time")
     plt.xticks(rotation=90, fontsize=24)
-    y_ticks  = [item[0] for item in sorted(status_rank_map.items(), key=lambda item: item[1])]  # orders keys based on their values in ascending order
+    y_ticks  = [item[0] for item in sorted(STATUS_RANK_MAP.items(), key=lambda item: item[1])]  # orders keys based on their values in ascending order
     plt.yticks(np.arange(len(y_ticks)), y_ticks, fontsize=24)     # restore string status names, overwrite numerical ranks
 
     ax.margins(y=0.25)

--- a/src/output/viz/viz.py
+++ b/src/output/viz/viz.py
@@ -194,9 +194,9 @@ def create_goal_status_over_time(agency, apg_name, dir=DEFAULT_DIRECTORY, name="
     ax.axhline(2.5, color="white")
 
     # Lines dividing fiscal years
-    ax.axvline(3.5, color="white", linestyle="--", dashes=[6,9])
-    ax.axvline(7.5, color="white", linestyle="--", dashes=[6,9])
-    ax.axvline(11.5, color="white", linestyle="--", dashes=[6,9])
+    ax.axvline(3.5, color="white", linestyle="--", dashes=[6,9], linewidth=3)
+    ax.axvline(7.5, color="white", linestyle="--", dashes=[6,9], linewidth=3)
+    ax.axvline(11.5, color="white", linestyle="--", dashes=[6,9], linewidth=3)
 
     status_ranked = pd.Series([STATUS_RANK_MAP[status] for status in list(apg_status_df["Status"])])    # List of numerical ranking of APG statuses in chronological order, needed to correctly order statuses on y-axis
 


### PR DESCRIPTION
This pull request includes editing of the `STATUS_RANK_MAP` constant to be more compatible with the goal status over time plot. The edit does not affect the other uses of this constant across the project, as all other implementations make use of the ranked order of the statuses rather than their associated numerical values. 