### PR TITLE
Rename columns from cover sheet data to reflect dummy dataset

### DIFF
--- a/src/input/cover_sheet_reading.py
+++ b/src/input/cover_sheet_reading.py
@@ -67,7 +67,7 @@ def read_cover_sheet(document):
 
                         index = max(checked_index, unchecked_index)
                         checkbox = row_text.pop(index)
-                        column_title = row_text.pop(index).lower().replace(" ", "_")    # converts to snake_case
+                        column_title = row_text.pop(index)
 
                         data[column_title] = 1 if checkbox == "☒" else 0   # stores a 1 if box is checked, else 0
     

--- a/src/input/cover_sheet_reading.py
+++ b/src/input/cover_sheet_reading.py
@@ -9,14 +9,14 @@ import pandas as pd
 
 # Maps headers on cover sheet to columns in the data
 HEADER_MAP = {
-    "What is blocking you?": "blockers_description",
-    "Add your own tags": "tags",
-    "How can the White House help?": "help_white_house",
-    "How can other agencies help?": "help_other_agencies",
-    "How can Congress help?": "help_congress",
-    "How can industry help?": "help_industry",
-    "How can the third sector (non-profits and non-governmental organizations) help?": "help_third_sector",
-    "How can academia help?": "help_academia"
+    "What is blocking you?": "Blockers",
+    "Add your own tags": "Tags",
+    "How can the White House help?": "White House help",
+    "How can other agencies help?": "Other agencies help",
+    "How can Congress help?": "Congress help",
+    "How can industry help?": "Industry help",
+    "How can the third sector (non-profits and non-governmental organizations) help?": "Third sector help",
+    "How can academia help?": "Academia help"
 }
 
 

--- a/src/input/cover_sheet_reading.py
+++ b/src/input/cover_sheet_reading.py
@@ -2,7 +2,7 @@
 Functions realted to scraping the data from an incoming cover sheet.
 """
 
-import src.utility
+import src.utility as utility
 
 from docx.text.paragraph import Paragraph
 import pandas as pd


### PR DESCRIPTION
The dummy dataset used up to this point has included column names that do not match the ones in the created dataset from the scraped data. 

While this pull request corrects all of the common columns between the dummy dataset and the one created from cover sheet data, please note that **there are still some essential columns missing from the cover sheet DataFrame. This is because the current version of the cover sheet does not collect those fields.** Missing fields include:
- Fiscal year
- Quarter
- Agency name
- APG name

Working toward #59.