### PR TITLE
Fix blank page created at the end of agency summary report

### DIFF
--- a/src/output/docx/output_creation.py
+++ b/src/output/docx/output_creation.py
@@ -93,14 +93,15 @@ def create_summary_document(agency, output_filename, output_dir="src/output/docx
 
     tpl.render(replacement_map)
 
-    apgs_list = agency.get_goals()
-    
     # Removes a blank line added after the final table in the template when render() is called, which resulted in a blank page being rendered. Sourced from https://github.com/python-openxml/python-docx/issues/33#issuecomment-77661907
-    p = tpl.docx.paragraphs[-1]._element    # retrieves final paragraph
-    p.getparent().remove(p)     # removes final pargraph
-    p._p = p._element = None
+    for p in utility.get_trailing_blank_paragraphs(tpl.docx):
+        p = p._element
+        p.getparent().remove(p)     # removes line
+        p._p = p._element = None
 
     tpl.docx.add_page_break()   # add page break prior to APG breakdown pages
+
+    apgs_list = agency.get_goals()
 
     # Loops for every APG that the agency holds
     for i in range(len(apgs_list)):

--- a/src/output/docx/output_creation.py
+++ b/src/output/docx/output_creation.py
@@ -94,6 +94,12 @@ def create_summary_document(agency, output_filename, output_dir="src/output/docx
     tpl.render(replacement_map)
 
     apgs_list = agency.get_goals()
+    
+    # Removes a blank line added after the final table in the template when render() is called, which resulted in a blank page being rendered. Sourced from https://github.com/python-openxml/python-docx/issues/33#issuecomment-77661907
+    p = tpl.docx.paragraphs[-1]._element    # retrieves final paragraph
+    p.getparent().remove(p)     # removes final pargraph
+    p._p = p._element = None
+
     tpl.docx.add_page_break()   # add page break prior to APG breakdown pages
 
     # Loops for every APG that the agency holds

--- a/src/output/docx/output_creation.py
+++ b/src/output/docx/output_creation.py
@@ -93,12 +93,7 @@ def create_summary_document(agency, output_filename, output_dir="src/output/docx
 
     tpl.render(replacement_map)
 
-    # Removes a blank line added after the final table in the template when render() is called, which resulted in a blank page being rendered. Sourced from https://github.com/python-openxml/python-docx/issues/33#issuecomment-77661907
-    for p in utility.get_trailing_blank_paragraphs(tpl.docx):
-        p = p._element
-        p.getparent().remove(p)     # removes line
-        p._p = p._element = None
-
+    remove_trailing_paragraphs(tpl.docx)    # if there are trailing blank paragraphs at the end of the document, a blank page may be created when the page break is added on the line below
     tpl.docx.add_page_break()   # add page break prior to APG breakdown pages
 
     apgs_list = agency.get_goals()
@@ -191,3 +186,15 @@ def get_goal_status_table(agency):
         table.append({"cols": row})     # appends row to the table object
 
     return table
+
+def remove_trailing_paragraphs(docx):
+    """
+    Removes all of the blank paragraphs at the end of the passed Document object.
+
+    :param docx: A docx Document object.
+    """
+    # Removes a blank line added after the final table in the template when render() is called, which resulted in a blank page being rendered. Sourced from https://github.com/python-openxml/python-docx/issues/33#issuecomment-77661907
+    for p in utility.get_trailing_blank_paragraphs(docx):
+        p = p._element
+        p.getparent().remove(p)     # removes line
+        p._p = p._element = None

--- a/src/utility.py
+++ b/src/utility.py
@@ -94,3 +94,20 @@ def richtext_is_empty(rt):
     :return: TRUE if the RichText object is empty (i.e., does not have any text), FALSE otherwise.
     """
     return rt.xml == ""
+
+def get_trailing_blank_paragraphs(docx):
+    """
+    Returns a list of Paragraph objects representing the blank lines at the end of the passed Document object.
+
+    :param docx: A docx Document object.
+    :return: A list of Paragraph objects that are at the end of the the passed document. Returns an empty list if no blank lines were found at the end of the document.
+    """
+    reversed_block_items = list(iter_block_items(docx))  # converts generator to list
+    reversed_block_items.reverse()  # reverses the order of the list of block items, i.e., placing the final blocks at the beginning of the list
+    lines_to_remove = []
+
+    # Checks if the last line of the template document is empty, adds to list of lines to remove if it is. This prevents extra blank lines at the end of the document, potentially creating a blank page when a page break is added.
+    while len(reversed_block_items) != 0 and isinstance(reversed_block_items[0], Paragraph) and reversed_block_items[0].text == "":
+        lines_to_remove.append(reversed_block_items.pop(0))
+
+    return lines_to_remove


### PR DESCRIPTION
Multiple functions are introduced in this pull request that help to achieve the title. The functions retrieve all of the paragraphs at the end of the document that are blank via the `iter_block_items()` function and remove the paragraphs via the code sourced from the GitHub link in the comments. This implementation was decided on after realizing that there were always blank lines following the summary template rendering, which caused a new page with only the blank line, resulting in the `Document.add_page_break()` function creating what appeared to be a completely empty page.

Resolves #19.