### PR TITLE
Create functions to retrieve cover sheets

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,11 +3,17 @@ File to be run to generate summary reports for the most recent quarter
 """
 import src.output.docx.output_creation as output_creation
 from src.objects.agency import Agency
+from src.input.cover_sheet_reading import process_cover_sheets, get_cover_sheets
 import pandas as pd
 
 from src.constants import AGENCY_ABBREVIATION_TO_NAME
 
 if __name__ == "__main__":
+    # Read cover sheet files
+    new_cover_sheets = get_cover_sheets()   # retrieves newly published cover sheets
+    new_cover_sheets_df = process_cover_sheets(new_cover_sheets)    # creates DataFrame using newly retrieved cover sheets  
+
+    # Create summary reports
     for agency_abbreviation in AGENCY_ABBREVIATION_TO_NAME.keys():
         file_name = f"{agency_abbreviation}_Summary"
         agency = Agency(pd.read_csv("../dummy_cover_sheet_data.csv"), agency_abbreviation, "Q4", 2020)

--- a/src/constants.py
+++ b/src/constants.py
@@ -52,3 +52,8 @@ AGENCY_NAME_TO_ABBREVIATION = {
 AGENCY_ABBREVIATION_TO_NAME = {value: key for key, value in AGENCY_NAME_TO_ABBREVIATION.items()}
 
 VIZ_DIRECTORY = "src/output/viz/images/"
+
+"""
+A path to the directory in which cover sheets are stored (relative to the location of the project's root).
+"""
+COVER_SHEET_DIRECTORY = "../cover_sheet/cover_sheets/"

--- a/src/input/cover_sheet_reading.py
+++ b/src/input/cover_sheet_reading.py
@@ -101,7 +101,11 @@ def get_cover_sheets(path=None):
     if path == None:
         path = COVER_SHEET_DIRECTORY    # retrieves cover sheets from the default directory specified by a constant if no path was passed
 
-    for filename in os.listdir(path):  # retrieves all file names from cover sheet directory
-        cover_sheets.append(Document(f"{path}{filename}"))     # creates Document objects for every cover sheet
+    try:
+        for filename in os.listdir(path):  # retrieves all file names from cover sheet directory
+            cover_sheets.append(Document(f"{path}{filename}"))     # creates Document objects for every cover sheet
+    except FileNotFoundError as e:
+        print(f"Unable to retrieve cover sheets from path {path}")
+        return None
 
     return cover_sheets

--- a/src/input/cover_sheet_reading.py
+++ b/src/input/cover_sheet_reading.py
@@ -89,15 +89,19 @@ def process_cover_sheets(cover_sheets_list):
         
     return pd.DataFrame(data)
 
-def get_cover_sheets():
+def get_cover_sheets(path=None):
     """
     Returns a list of docx Document objects representing cover sheets, each of which are retrieved from the folder where cover sheets are stored.
 
+    :param path: The path to the directory where cover sheet objects are stored. NOTE: This directory should only include cover sheets.
     :return: A list of docx Document objects representing cover sheets, each of which are retrieved from the folder where cover sheets are stored.
     """
     cover_sheets = []
 
-    for filename in os.listdir(COVER_SHEET_DIRECTORY):  # retrieves all file names from cover sheet directory
-        cover_sheets.append(Document(f"{COVER_SHEET_DIRECTORY}{filename}"))     # creates Document objects for every cover sheet
+    if path == None:
+        path = COVER_SHEET_DIRECTORY    # retrieves cover sheets from the default directory specified by a constant if no path was passed
+
+    for filename in os.listdir(path):  # retrieves all file names from cover sheet directory
+        cover_sheets.append(Document(f"{path}{filename}"))     # creates Document objects for every cover sheet
 
     return cover_sheets

--- a/src/input/cover_sheet_reading.py
+++ b/src/input/cover_sheet_reading.py
@@ -3,9 +3,12 @@ Functions realted to scraping the data from an incoming cover sheet.
 """
 
 import src.utility as utility
+from src.constants import COVER_SHEET_DIRECTORY
 
+from docx import Document
 from docx.text.paragraph import Paragraph
 import pandas as pd
+import os
 
 # Maps headers on cover sheet to columns in the data
 HEADER_MAP = {
@@ -85,3 +88,16 @@ def process_cover_sheets(cover_sheets_list):
         data.append(read_cover_sheet(cover_sheet))
         
     return pd.DataFrame(data)
+
+def get_cover_sheets():
+    """
+    Returns a list of docx Document objects representing cover sheets, each of which are retrieved from the folder where cover sheets are stored.
+
+    :return: A list of docx Document objects representing cover sheets, each of which are retrieved from the folder where cover sheets are stored.
+    """
+    cover_sheets = []
+
+    for filename in os.listdir(COVER_SHEET_DIRECTORY):  # retrieves all file names from cover sheet directory
+        cover_sheets.append(Document(f"{COVER_SHEET_DIRECTORY}{filename}"))     # creates Document objects for every cover sheet
+
+    return cover_sheets


### PR DESCRIPTION
This pull request includes the framework of retrieving cover sheets from a defined directory. Notable features included are:
- A constant, `COVER_SHEET_DIRECTORY`, storing the path to the location of the cover sheets relative to base directory of the project.
- A function that retrieves, creates docx Document objects for each cover sheet document in the specified path (or, if no path is entered, from the default diretory.
- Integrates reading cover sheets into `main.py`. This is largely a placeholder, as the read data is not stored anywhere, but this sets a roadmap for a future pull request to integrate the storage of this data. 

Progresses toward #59.