### PR TITLE
Add dynamic challenge recommendations to challenge bullets

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -32,7 +32,7 @@ CHALLENGES_RECOMMENDATIONS_MAP_PATH = "src/resources/templates/excel/challenges_
 Constants related to the challenges expressed by APG teams
 """
 CHALLENGES_RECOMMENDATIONS_MAP_DF = pd.read_excel(CHALLENGES_RECOMMENDATIONS_MAP_PATH)
-CHALLENGES_LIST = ["Hiring", "Competing deadlines", "Legislation", "Lack of research", "Unclear guidance", "Unavailable data"]
+CHALLENGES_LIST = ["Hiring technical staff", "Competing deadlines", "Legislation", "Lack of research", "Unclear guidance", "Unavailable data"]
 
 AGENCY_NAME_TO_ABBREVIATION = {
     "Department of Agriculture": "USDA", 

--- a/src/output/docx/output_creation.py
+++ b/src/output/docx/output_creation.py
@@ -121,7 +121,7 @@ def create_summary_document(agency, output_filename, output_dir="src/output/docx
             "speedometer_text": text_templates.get_speedometer_summary_text(agency, apg),
             "blockers_text": text_templates.get_blockers_text(agency, apg),
             "group_assistance_text": text_templates.get_group_help_text(agency, apg),
-            "challenge_bullets": text_templates.get_apg_challenges_bullets(agency, apg),
+            "challenge_bullets": text_templates.get_apg_challenges_bullets(agency, apg, tpl),
             "success_story": text_templates.get_success_story(agency, apg)
         }
 

--- a/src/output/text/processing/excel.py
+++ b/src/output/text/processing/excel.py
@@ -3,7 +3,7 @@ Module capable of rendering text sourced from template Excel files.
 """
 import src.output.text.processing.markdown as markdown
 
-from src.constants import TEXT_BLOCK_TEMPLATES_DF
+from src.constants import TEXT_BLOCK_TEMPLATES_DF, CHALLENGES_RECOMMENDATIONS_MAP_DF
 
 def get_richtext_from_variable(variable_name, placeholders_dict, tone="neutral"):
     """
@@ -22,6 +22,20 @@ def get_richtext_from_variable(variable_name, placeholders_dict, tone="neutral")
     text = __fill_placeholders(text, placeholders_dict)
 
     return markdown.string_to_richtext(text)
+
+def get_recommendations_for_challenge(challenge_name):
+    """
+    Returns a list of dictionaries including the challenge name, recommendation, URL and explanation for all of the recommendations for the passed challenge.
+
+    :param challenge_name: The name of the challenge from which challenges will be retrieved.
+    :return: A list of dictionaries, which hold the following keys:
+        - Challenge Name: The name of the challenge that is connected to the recommendation.
+        - Recommended Action: The recommendation based on the challenge identified.
+        - URL: A URL linking to a page that provides more information on the recommended action.
+        - Explanation: An explanation of why the recommended action was recommended for the challenge.
+    """
+    recommendations_df = CHALLENGES_RECOMMENDATIONS_MAP_DF.loc[CHALLENGES_RECOMMENDATIONS_MAP_DF["Challenge Name"] == challenge_name]
+    return recommendations_df.to_dict("records")
 
 def __fill_placeholders(text, placeholders_dict):
     """

--- a/src/output/text/text_templates.py
+++ b/src/output/text/text_templates.py
@@ -6,6 +6,7 @@ import src.objects.agency as agency
 import src.utility as utility
 import src.output.data.df_creator as df_creator
 from src.output.text.processing.excel import get_richtext_from_variable
+import src.output.text.processing.excel as excel
 
 from docxtpl import RichText
 import numpy as np
@@ -184,12 +185,13 @@ def get_group_help_text(agency, apg_name):
 
     return __process_template_output(rt)
 
-def get_apg_challenges_bullets(agency, apg_name):
+def get_apg_challenges_bullets(agency, apg_name, tpl):
     """
     Returns a RichText object listing out the challenges reported by the APG goal team during the reported quarter, which is capable of being represented as a bulleted list. NOTE: The returned RichText object itself does not return a bulleted list, but each paragraph renders as a bullet when placed in a bulleted list in a template document.
 
     :param agency: An Agency object representing a CFO Act agency at a given point in time.
     :param apg_name: The name of the APG whose status will be summarized.
+    :param tpl: An initialized DocxTemplate object. The object is required to create hyperlinks, but is not modified in any way within this function.
     :return: A RichText object object listing out the challenges reported by the APG goal team during the reported quarter, which is capable of being represented as a bulleted list. 
     """
     rt = RichText()
@@ -201,6 +203,18 @@ def get_apg_challenges_bullets(agency, apg_name):
         challenge = challenges_list[i]
 
         rt.add(f"{challenge}", font="Roboto")
+
+        recs = excel.get_recommendations_for_challenge(challenge)  # retrieves all recommendations for the given challenge
+        
+        if len(recs):
+            rt.add(" — consider the following: ", font="Roboto")    # transition text
+            
+            for j in range(len(recs)):
+                rec = recs[j]
+                rt.add(f"{rec['Recommended Action']}", font="Roboto", url_id=tpl.build_url_id(rec["URL"]), color="#0000FF", underline=True) # adds recommended action with hyperlink
+
+                if j != len(recs) - 1:
+                    rt.add(", ", font="Roboto")     # adds commas to separate challenges
 
         if i != len(challenges_list) - 1:
             rt.add("\a")    # adds a paragraph break following each challenge (except for the final one)


### PR DESCRIPTION
Recommendations come following a dash directly after the listed challenge in the "Challenges identified this quarter" section (screenshot seen below). Utilizes the spreadsheet mapping challenges to recommendations.

Progresses toward #81, although not enough to close, as this design is not optimal and should be improved upon.

![image](https://user-images.githubusercontent.com/51730872/128063217-c82e6544-a9f1-44ba-b64c-5c4e5c99ecd0.png)
