### PR TITLE
Introduce function to support updating central database with cover sheet data

### DIFF
--- a/src/input/upload.py
+++ b/src/input/upload.py
@@ -1,0 +1,27 @@
+"""
+Functions related to updating the central database with the most recently read cover sheets.
+"""
+
+import pandas as pd
+
+def update_database(database_path, new_data_df):
+    """
+    Updates the databased located at the passed path with the new data (read from cover sheets) passed as an argument appended as new rows.
+
+    :param database_path: The path to the central data storage for the project. Only supports .csv files (could be expanded in the future).
+    :param new_data_df: A DataFrame holding data to be added to the database, presumably read from cover sheets.
+    """
+    database = pd.read_csv(database_path)
+    different_columns = new_data_df.columns.difference(database.columns).to_list()  # list of columns in the cover sheets but not in database
+
+    # If there are columns in the new data that are not included in the database
+    if len(different_columns) > 0:
+        added_cols_str = "WARNING: The following three data fields were retrieved from the cover sheet that are not present in the database:\n"
+        for column in different_columns:
+            added_cols_str += f"\t\"{column}\"\n"
+
+        print(added_cols_str)
+
+    database = database.append(new_data_df)
+
+    database.to_csv(database_path, index=False)

--- a/src/objects/agency.py
+++ b/src/objects/agency.py
@@ -137,7 +137,7 @@ class Agency():
         :param goal_name: The name of the APG from which the challenges reported will be returned.
         :return: A list of the challenges reported by the passed goal team.
         """
-        return self.get_apg_row(goal_name)[CHALLENGES_LIST].columns[(self.get_apg_row(goal_name)[CHALLENGES_LIST] == "Yes").all()].tolist()     # list of challenge columns that are in the affirmative
+        return self.get_apg_row(goal_name)[CHALLENGES_LIST].columns[(self.get_apg_row(goal_name)[CHALLENGES_LIST] == 1).all()].tolist()     # list of challenge columns that are in the affirmative
 
     def get_themes(self, goal_name):
         """
@@ -146,7 +146,7 @@ class Agency():
         :param goal_name: The name of the APG from which the challenges reported will be returned.
         :return: A list of the themes connected to the the passed goal.
         """
-        return self.get_apg_row(goal_name)[THEMES_LIST].columns[(self.get_apg_row(goal_name)[THEMES_LIST] == "Off").all()].tolist()
+        return self.get_apg_row(goal_name)[THEMES_LIST].columns[(self.get_apg_row(goal_name)[THEMES_LIST] == 0).all()].tolist()
 
     def get_apg_row(self, goal_name, year=None, quarter=None):
         """
@@ -170,7 +170,7 @@ class Agency():
         :return: A DataFrame where each row is a unique instance of an APG team within the passed theme that is addressing the passed challenge in the current quarter.
         """
         common_agencies_df = self.get_df().loc[(self.get_df()["Quarter"] == self.get_quarter()) & (self.get_df()["Fiscal Year"] == self.get_year())]    # retrieves slice of DataFrame for current year and quarter
-        common_agencies_df = common_agencies_df.loc[(common_agencies_df[theme] == "Yes") & (common_agencies_df[challenge] == "Yes")]  # filters DataFrame for only agencies with common themes, challenges
+        common_agencies_df = common_agencies_df.loc[(common_agencies_df[theme] == 1) & (common_agencies_df[challenge] == 1)]  # filters DataFrame for only agencies with common themes, challenges
         common_agencies_df = common_agencies_df.loc[common_agencies_df["Agency Name"] != self.get_name()]   # filters the calling agency out of the DataFrame returned
 
         return common_agencies_df

--- a/src/output/data/df_creator.py
+++ b/src/output/data/df_creator.py
@@ -33,7 +33,7 @@ def get_recurring_challenges_count(df):
         for goal in agency_goals:
             for challenge in CHALLENGES_LIST:
                 # gets the index of the last time the challenge wasn't reported, i.e., the number of consecutive quarters it was reported
-                consecutive_reports = (sorted_df.loc[sorted_df["Goal Name"] == goal].reset_index(drop=True)[challenge] == "Off").idxmax() 
+                consecutive_reports = (sorted_df.loc[sorted_df["Goal Name"] == goal].reset_index(drop=True)[challenge] == 0).idxmax() 
                 data.append({
                     "Agency Name": agency, 
                     "Goal Name": goal,
@@ -57,13 +57,13 @@ def get_challenge_count_by_quarter(df):
 
         data_df = data_df.groupby(["Agency Name", "Fiscal Year", "Quarter", challenge]).size().reset_index().rename(columns={0: "Count"})
 
-        # Error handling: groupby will not create any rows of "Yes" values if the agency never identified the given challenge. Checking to see if data_df only contains unchecked challenges
-        if len(data_df.loc[(data_df[challenge] == "Yes")]) == 0 and len(data_df.loc[(data_df[challenge] == "Off")]) == len(data_df):
+        # Error handling: groupby will not create any rows with value of 1 if the agency never identified the given challenge. Checking to see if data_df only contains unchecked challenges
+        if len(data_df.loc[(data_df[challenge] == 1)]) == 0 and len(data_df.loc[(data_df[challenge] == 0)]) == len(data_df):
             # Converts the count of the unchecked challenges to its inverse: a count of all the times the challenge was checked.
-            data_df[challenge] = "Yes"
+            data_df[challenge] = 1
             data_df["Count"] = 0
         else:
-            data_df = data_df.loc[(data_df[challenge] == "Yes")]
+            data_df = data_df.loc[(data_df[challenge] == 1)]
         
         # Change column with challenge name to general "Challenge" column, filled with the unique challenge name
         data_df[challenge] = challenge


### PR DESCRIPTION
This pull request includes a function that may be used to update the central database with the data extracted from cover sheets. The function is admittedly not perfect and has room for improvement, as it currently requires the path to the database to be passed to it and only supports CSV files. Limited as it may be, this function will serve as a place to error handle bad inputs from the cover sheet data (#59).

Also introduced in this pull request is the updating of the code to handle binary fields of 1 and 0, which is consistent with the way the cover sheet data is collected, instead of "Yes" and "Off", as is present in the dummy data. This, of course, enables a smoother upload of data that is compatible with the central database.