### PR TITLE
Add ability to control which new columns are added to the central database

### DIFF
--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ File to be run to generate summary reports for the most recent quarter
 import src.output.docx.output_creation as output_creation
 from src.objects.agency import Agency
 from src.input.cover_sheet_reading import process_cover_sheets, get_cover_sheets
+from src.input.upload import update_database
 import pandas as pd
 
 from src.constants import AGENCY_ABBREVIATION_TO_NAME
@@ -12,6 +13,7 @@ if __name__ == "__main__":
     # Read cover sheet files
     new_cover_sheets = get_cover_sheets()   # retrieves newly published cover sheets
     new_cover_sheets_df = process_cover_sheets(new_cover_sheets)    # creates DataFrame using newly retrieved cover sheets  
+    # update_database("../dummy_cover_sheet_data.csv", new_cover_sheets_df)     # uncomment this line to initiate the reading of cover sheets and storage into the database
 
     # Create summary reports
     for agency_abbreviation in AGENCY_ABBREVIATION_TO_NAME.keys():

--- a/src/input/upload.py
+++ b/src/input/upload.py
@@ -11,6 +11,8 @@ def update_database(database_path, new_data_df):
     :param database_path: The path to the central data storage for the project. Only supports .csv files (could be expanded in the future).
     :param new_data_df: A DataFrame holding data to be added to the database, presumably read from cover sheets.
     """
+    # NOTE: In future refinements of this function, there is an opportunity to reject input/raise an error here if certain columns are missing (e.g., Quarter, Fiscal Year and Agency Name).
+
     database = pd.read_csv(database_path)
     different_columns = new_data_df.columns.difference(database.columns).to_list()  # list of columns in the cover sheets but not in database
 

--- a/src/input/upload.py
+++ b/src/input/upload.py
@@ -22,15 +22,12 @@ def update_database(database_path, new_data_df):
 
         # Console prompt asking user whether or not they want to add new columns to database
         added_cols_str += "Would you like to add all of these columns to the database? Enter Y/N: "
-        create_new_columns = input(added_cols_str)
+        
+        create_new_columns = handle_yes_no_input(added_cols_str)
 
-        # Handling bad input
-        while create_new_columns not in ["Y", "N"]:
-            create_new_columns = input(f"\"{create_new_columns}\" is not a valid input. Please enter \"Y\" or \"N\": ")
-
-        if create_new_columns == "Y":
+        if create_new_columns:
             database = database.append(new_data_df)     # appends new data with new columns, which are set at values of NaN for all previous entries
-        elif create_new_columns == "N":
+        else:
             common_cols = (new_data_df.columns & database.columns).tolist()
             common_slice = new_data_df.loc[:, common_cols]  # only selects columns from new data DataFrame that are in database, no new columns added
             
@@ -39,3 +36,18 @@ def update_database(database_path, new_data_df):
         database = database.append(new_data_df)
 
     database.to_csv(database_path, index=False)
+
+def handle_yes_no_input(prompt):
+    """
+    Error checks yes/no input, returns true or false depending on the input of the user.
+
+    :param prompt: The prompt used to retrieve a Y/N answer from the user.
+    :return: TRUE if the user enters "Y", FALSE if the user enters "N".
+    """
+    user_input = input(prompt).upper()
+
+    # Handling bad input
+    while user_input not in ["Y", "N"]:
+        user_input = input(f"\"{user_input}\" is not a valid input. Please enter \"Y\" or \"N\": ")
+
+    return user_input == "Y"

--- a/src/input/upload.py
+++ b/src/input/upload.py
@@ -20,8 +20,22 @@ def update_database(database_path, new_data_df):
         for column in different_columns:
             added_cols_str += f"\t\"{column}\"\n"
 
-        print(added_cols_str)
+        # Console prompt asking user whether or not they want to add new columns to database
+        added_cols_str += "Would you like to add all of these columns to the database? Enter Y/N: "
+        create_new_columns = input(added_cols_str)
 
-    database = database.append(new_data_df)
+        # Handling bad input
+        while create_new_columns not in ["Y", "N"]:
+            create_new_columns = input(f"\"{create_new_columns}\" is not a valid input. Please enter \"Y\" or \"N\": ")
+
+        if create_new_columns == "Y":
+            database = database.append(new_data_df)     # appends new data with new columns, which are set at values of NaN for all previous entries
+        elif create_new_columns == "N":
+            common_cols = (new_data_df.columns & database.columns).tolist()
+            common_slice = new_data_df.loc[:, common_cols]  # only selects columns from new data DataFrame that are in database, no new columns added
+            
+            database = database.append(common_slice)
+    else:   # if all columns in new data are in database
+        database = database.append(new_data_df)
 
     database.to_csv(database_path, index=False)

--- a/src/input/upload.py
+++ b/src/input/upload.py
@@ -28,7 +28,15 @@ def update_database(database_path, new_data_df):
         if create_new_columns:
             database = database.append(new_data_df)     # appends new data with new columns, which are set at values of NaN for all previous entries
         else:
+            # Retrieving list of columns in both database and new data
             common_cols = (new_data_df.columns & database.columns).tolist()
+            
+            # Initiating the addition of some of the columns in the new data, but not all
+            if handle_yes_no_input("Would you like to add some, but not all, of the above listed columns to the database? Enter Y/N: "):
+                for column in different_columns:
+                    if handle_yes_no_input(f"Would you like to add the \"{column}\" column? Enter Y/N: "):
+                        common_cols.append(column)  # add the selected column to the list of columns to be used
+            
             common_slice = new_data_df.loc[:, common_cols]  # only selects columns from new data DataFrame that are in database, no new columns added
             
             database = database.append(common_slice)


### PR DESCRIPTION
Utilizes console-based user input to decide which new columns from the new data to add to the central database. This feature was implemented in the event that the cover sheet data should change, therefore meaning that the fields collected have changed: the implementation in this pull request can likely be perfected, but this pull request is more about providing code to prompt the conversation about what to do when the cover sheet is changed/begins to collect new info.

This pull request resolves #59. Admittedly, this issue is not totally solved, as most of it should likely be addressed via the technique of restricting field editing in the cover sheet Word document (see [this comment on the original ticket](https://github.com/jasondamico/pgov-cover-sheet-reader/issues/59#issuecomment-894485422) for more explanation and a link on how to do this).