### PR TITLE
Improve modularity and readability of cover sheet reading script

### DIFF
--- a/src/input/cover_sheets/reading.py
+++ b/src/input/cover_sheets/reading.py
@@ -21,16 +21,17 @@ def read_cover_sheet(document):
     header = None
 
     for block in utility.iter_block_items(document):
-        if isinstance(block, Paragraph):
+        if isinstance(block, Paragraph):    # handling of paragraphs
             if block.text in HEADER_MAP.keys():     # if the paragraph holds one of the headers used to indicate that text can be inputted from user
-                header = block.text
+                header = block.text     # stores text as a header
         else:   # if block is Table object
             if header:  # if table comes directly after a recognized header
                 table_data = get_list_from_table(block)
 
+                # Storing of data under the mapped column name, resetting header to read more data
                 data[HEADER_MAP[header]] = " ".join(table_data)
                 header = None
-            else:
+            else:   # for tables that do not come directly after headers
                 for row in block.rows:
                     row_text = []
                     for cell in row.cells:

--- a/src/input/cover_sheets/reading.py
+++ b/src/input/cover_sheets/reading.py
@@ -39,10 +39,10 @@ def read_cover_sheet(document):
                             row_text.append(paragraph.text)     # collects all paragraphs in a given cell into a list
 
                     # storing of checkboxes in data field - continues until all checkboxes are retrieved from cell
-                    while checkbox_in_row(row_text):
+                    while __checkbox_in_row(row_text):
                         # Retrieves index of the first checked and unchecked checkboxes
-                        checked_index = get_checkbox_index(row_text, True)
-                        unchecked_index = get_checkbox_index(row_text, False)
+                        checked_index = __get_checkbox_index(row_text, True)
+                        unchecked_index = __get_checkbox_index(row_text, False)
 
                         index = max(checked_index, unchecked_index)     # retrives the maximum index value, meaning index -1 is never selected
                         checkbox_value = 1 if index == checked_index else 0
@@ -52,6 +52,8 @@ def read_cover_sheet(document):
                         data[column_title] = checkbox_value   # stores a 1 if box is checked, else 0
     
     return data
+
+# DOCUMENT RETRIEVAL METHODS
 
 def process_cover_sheets(cover_sheets_list):
     """
@@ -87,6 +89,8 @@ def get_cover_sheets(path=None):
 
     return cover_sheets
 
+# DATA READING METHODS
+
 def get_list_from_table(table):
     """
     Given a passed table, returns a list with each element representing the data held in a cell of the table. Parses through the table from top to bottom, going left to right in each row.
@@ -106,7 +110,7 @@ def get_list_from_table(table):
 
     return text_input
 
-def checkbox_in_row(row):
+def __checkbox_in_row(row):
     """
     Given a list of data from a row, return TRUE if there is a checkbox in the row, FALSE otherwise.
 
@@ -115,7 +119,7 @@ def checkbox_in_row(row):
     """
     return any([checkbox in row_element for row_element in row for checkbox in ["☒", "☐"]])
 
-def get_checkbox_index(row, is_checked):
+def __get_checkbox_index(row, is_checked):
     """
     Given a list of data from a row, return the index of first occurrence the passed check type. Returns -1 if the check type is not present in the list.
 

--- a/src/input/cover_sheets/reading.py
+++ b/src/input/cover_sheets/reading.py
@@ -118,3 +118,22 @@ def checkbox_in_row(row):
     :return: TRUE if a checkbox is in the row, FALSE otherwise.
     """
     return any([checkbox in row_element for row_element in row for checkbox in ["☒", "☐"]])
+
+def get_checkbox_index(row, is_checked):
+    """
+    Given a list of data from a row, return the index of first occurrence the passed check type. Returns -1 if the check type is not present in the list.
+
+    :param row: A list of data from a row within a Word document table.
+    :param is_checked: Boolean corresponding to whether the desired index is of checked checkboxes (true) or unchecked checkboxes (unchecked).
+    :return: The index of the list that contains the specified checkbox type if it is present. Otherwise, return -1.
+    """
+    if is_checked:
+        checkbox = "☒"
+    else:
+        checkbox = "☐"
+
+    for id, cell_text in enumerate(row):
+        if checkbox in cell_text:
+            return id   # returns the ID if the specified checkbox is found
+    
+    return -1   # returns -1 if the row is looped through and no checkbox is found

--- a/src/input/cover_sheets/reading.py
+++ b/src/input/cover_sheets/reading.py
@@ -38,22 +38,17 @@ def read_cover_sheet(document):
                             row_text.append(paragraph.text)     # collects all paragraphs in a given cell into a list
 
                     # storing of checkboxes in data field - continues until all checkboxes are retrieved from cell
-                        try:
-                            checked_index = row_text.index("☒")
-                        except:
-                            checked_index = -1
-
-                        try:
-                            unchecked_index = row_text.index("☐")
-                        except:
-                            unchecked_index = -1
                     while checkbox_in_row(row_text):
+                        # Retrieves index of the first checked and unchecked checkboxes
+                        checked_index = get_checkbox_index(row_text, True)
+                        unchecked_index = get_checkbox_index(row_text, False)
 
-                        index = max(checked_index, unchecked_index)
-                        checkbox = row_text.pop(index)
-                        column_title = row_text.pop(index)
+                        index = max(checked_index, unchecked_index)     # retrives the maximum index value, meaning index -1 is never selected
+                        checkbox_value = 1 if index == checked_index else 0
+                        row_text.pop(index)     # removes element with checkbox that is being added to data
+                        column_title = row_text.pop(index)  # removes element in row directly after checkbox, which is assumed to be the title of the checkbox field
 
-                        data[column_title] = 1 if checkbox == "☒" else 0   # stores a 1 if box is checked, else 0
+                        data[column_title] = checkbox_value   # stores a 1 if box is checked, else 0
     
     return data
 

--- a/src/input/cover_sheets/reading.py
+++ b/src/input/cover_sheets/reading.py
@@ -96,3 +96,22 @@ def get_cover_sheets(path=None):
         return None
 
     return cover_sheets
+
+def get_list_from_table(table):
+    """
+    Given a passed table, returns a list with each element representing the data held in a cell of the table. Parses through the table from top to bottom, going left to right in each row.
+
+    :param table: A Table element retrieved from a Table in a Word document containing data.
+    :return: A list containing all the data from the table.
+    """
+    text_input = []
+
+    for row in table.rows: 
+        for cell in row.cells:
+            paragraphs = []
+            for paragraph in cell.paragraphs:
+                paragraphs.append(paragraph.text)
+            
+            text_input.append("\n".join(paragraphs))    # separate each paragraph by a line break
+
+    return text_input

--- a/src/input/cover_sheets/reading.py
+++ b/src/input/cover_sheets/reading.py
@@ -25,16 +25,10 @@ def read_cover_sheet(document):
             if block.text in HEADER_MAP.keys():     # if the paragraph holds one of the headers used to indicate that text can be inputted from user
                 header = block.text
         else:   # if block is Table object
-            if header:  # if table comes directly after a header
-                text_input = None
-                for row in block.rows: 
-                    for cell in row.cells:
-                        for paragraph in cell.paragraphs: 
-                            if text_input:  # allows for multiple paragraphs in input
-                                text_input = "{} {}".format(text_input, paragraph.text)
-                            else:
-                                text_input = paragraph.text
-                data[HEADER_MAP[header]] = text_input
+            if header:  # if table comes directly after a recognized header
+                table_data = get_list_from_table(block)
+
+                data[HEADER_MAP[header]] = " ".join(table_data)
                 header = None
             else:
                 for row in block.rows:

--- a/src/input/cover_sheets/reading.py
+++ b/src/input/cover_sheets/reading.py
@@ -38,7 +38,6 @@ def read_cover_sheet(document):
                             row_text.append(paragraph.text)     # collects all paragraphs in a given cell into a list
 
                     # storing of checkboxes in data field - continues until all checkboxes are retrieved from cell
-                    while any([i in ["☒", "☐"] for i in row_text]):
                         try:
                             checked_index = row_text.index("☒")
                         except:
@@ -48,6 +47,7 @@ def read_cover_sheet(document):
                             unchecked_index = row_text.index("☐")
                         except:
                             unchecked_index = -1
+                    while checkbox_in_row(row_text):
 
                         index = max(checked_index, unchecked_index)
                         checkbox = row_text.pop(index)
@@ -109,3 +109,12 @@ def get_list_from_table(table):
             text_input.append("\n".join(paragraphs))    # separate each paragraph by a line break
 
     return text_input
+
+def checkbox_in_row(row):
+    """
+    Given a list of data from a row, return TRUE if there is a checkbox in the row, FALSE otherwise.
+
+    :param row: A list of data from a row within a Word document table.
+    :return: TRUE if a checkbox is in the row, FALSE otherwise.
+    """
+    return any([checkbox in row_element for row_element in row for checkbox in ["☒", "☐"]])


### PR DESCRIPTION
Several improvements are introduced in this pull request that vastly clean up the cover sheet reading script:
- The `read_cover_sheet()` function is broken down into several utility functions
- More descriptive comments throughout cover sheet reading functions
- Checkbox fields in cover sheet are now recognized as checkbox fields even if they have characters beyond just a checkbox. Prior to this pull request, they would only be recognized if they *only* contained a checkbox. **This massively improves the room for error if an APG team submits a cover sheet with accidental spaces, characters or paragraph breaks.**

This pull request makes me feel a whole lot better about both the malleability of the cover sheet reading system and its ability to be adapted over time. 

Resolves #98.